### PR TITLE
Alters default link style. Closes #114

### DIFF
--- a/dist/static/css/dhbox.css
+++ b/dist/static/css/dhbox.css
@@ -1089,8 +1089,8 @@ textarea {
   line-height: inherit;
 }
 a {
-  color: #2e1a57;
-  text-decoration: none;
+  color: #428bca;
+  text-decoration: underline;
 }
 a:hover,
 a:focus {
@@ -4488,6 +4488,7 @@ fieldset[disabled] .navbar-default .btn-link:focus {
 }
 .navbar-inverse .navbar-nav > li > a {
   color: #fff;
+  text-decoration: none;
 }
 .navbar-inverse .navbar-nav > li > a:hover,
 .navbar-inverse .navbar-nav > li > a:focus {


### PR DESCRIPTION
Changes default link color to #428bca and text-decoration to underline.
Adds text-decoration override to the navbar as underlining link in the
nav was not proposed as part of issue #114.

According to [this color validator](http://joshualondon.github.io/wcag-color-contrast-validator/) #428bca is WCAG 2.0 AAA compliant in our context.