### PR TITLE
Update install-dhbox.sh

### DIFF
--- a/install_dhbox.sh
+++ b/install_dhbox.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 apt-get update
-apt-get install wget pip nodejs nodejs-legacy git build-essential checkinstall libreadline-gplv2-dev libncursesw5-dev libssl-dev libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev npm python-pip
+apt-get install -y wget python-pip nodejs nodejs-legacy git build-essential checkinstall libreadline-gplv2-dev libncursesw5-dev libssl-dev libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev npm python-pip
 cd ~/Downloads/
 wget http://python.org/ftp/python/2.7.5/Python-2.7.5.tgz
 tar -xvf Python-2.7.5.tgz
@@ -12,8 +12,12 @@ wget -qO- https://get.docker.com/ | sh
 git clone https://github.com/DH-Box/dhbox.git
 cd ~/dhbox/
 pip install -r requirements.txt
-cd ~/dhbox/seed/
+cd seed/
 sudo docker build -t thedhbox/seed:latest .
+cd ../lamp-seed/
+sudo docker build -t tlamp .
+cd ../wp-seed/
+sudo docker build -t twordpress .
 cd ~/dhbox/
 ln -s /usr/bin/nodejs /usr/bin/node
 npm install -g bower gulp


### PR DESCRIPTION
Added ability to buid the new images to install-dhbox.sh. Think we should leave build-all.sh since it's useful for manual installs or if we have to rebuild images in testing, though we should swap it out for a docker compose soon. Will test on a fresh droplet once we merge.